### PR TITLE
Add loadAfter tag to enable Auto-sort

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -19,6 +19,9 @@
       </li>
      
     </modDependencies>
+    <loadAfter>
+      <li>roolo.giddyupcore</li>
+    </loadAfter>
 	
 		<packageId>roolo.giddyuprideandroll</packageId>
 	<description>Giddy-up! Let colonists Ride to their destination and Roll. 


### PR DESCRIPTION
Add loadAfter tag to About.xml so RimWorld's Auto-sort button can move this mod after Giddy-Up Core.

These same three lines should also be added to About.xml in the other (non-Core) Giddy-Up mods.