### PR TITLE
Add one more null check in Pawn_Jobtracker

### DIFF
--- a/v1.3/Source/Giddy-Up-Ride-and-Roll/Harmony/Pawn_Jobtracker.cs
+++ b/v1.3/Source/Giddy-Up-Ride-and-Roll/Harmony/Pawn_Jobtracker.cs
@@ -256,7 +256,7 @@ namespace GiddyUpRideAndRoll.Harmony
                     return true;
                 }
             }
-            if (animal.CurJob != null && animal.CurJob.def == JobDefOf.LayDown && animal.needs != null && animal.needs.rest.CurLevelPercentage < 0.5f)//only allow resting animals if they have enough energy. 
+            if (animal.CurJob != null && animal.CurJob.def == JobDefOf.LayDown && animal.needs?.rest != null && animal.needs.rest.CurLevelPercentage < 0.5f)//only allow resting animals if they have enough energy. 
             {
                 return true;
             }


### PR DESCRIPTION
Not all animals have a rest meter, for example animals from Android Tiers.
I added one more null check so that animals with no rest bars don't throw NRE while resting (resting because it is sick/about to have a surgery).
Might help solve #23 and #19 .