### PR TITLE
Fix performance impact from Pawn.GetGizmos() patch

### DIFF
--- a/v1.3/Source/Giddy-Up-Ride-and-Roll/Harmony/Pawn.cs
+++ b/v1.3/Source/Giddy-Up-Ride-and-Roll/Harmony/Pawn.cs
@@ -14,14 +14,17 @@ namespace GiddyUpRideAndRoll.Harmony
     [HarmonyPatch(typeof(Pawn), "GetGizmos")]
     public class Pawn_GetGizmos
     {
-        public static void Postfix(ref IEnumerable<Gizmo> __result, Pawn __instance)
+        public static IEnumerable<Gizmo> Postfix(IEnumerable<Gizmo> gizmos, Pawn __instance)
         {
-            List<Gizmo> gizmoList = __result.ToList();
+            foreach (Gizmo gizmo in gizmos)
+            {
+                yield return gizmo;
+            }
+
             if (__instance.RaceProps.Animal && __instance.CurJob != null && __instance.CurJob.def == GU_RR_DefOf.WaitForRider)
             {
-                gizmoList.Add(CreateGizmo_LeaveRider(__instance));
+                yield return CreateGizmo_LeaveRider(__instance);
             }
-            __result = gizmoList;
         }
         private static Gizmo CreateGizmo_LeaveRider(Pawn __instance)
         {


### PR DESCRIPTION
Pawn.GetGizmos() is an iterator method which is currently being
postfixed to add an extra gizmo, which forces initialization of the
returned IEnumerable. As a fix, convert the method to use a passthrough
postfix[1] which allows us to add our gizmo lazily.

DPA screenshot showing the overhead of the original method (when selecting a pawn):
![DPA](https://i.imgur.com/f2bzgle.png)

---
[1] https://harmony.pardeike.net/articles/patching-postfix.html#pass-through-postfixes